### PR TITLE
Add script measure compression ratio

### DIFF
--- a/nexus_producer/include/KafkaEventPublisher.h
+++ b/nexus_producer/include/KafkaEventPublisher.h
@@ -8,13 +8,17 @@
 
 class KafkaEventPublisher : public EventPublisher {
 public:
+  KafkaEventPublisher() {};
+  KafkaEventPublisher(const std::string &compression) : m_compression(compression) {};
+  ~KafkaEventPublisher() { RdKafka::wait_destroyed(5000); };
+
   void setUp(const std::string &broker, const std::string &topic) override;
   void sendMessage(char *buf, size_t messageSize) override;
-  ~KafkaEventPublisher() { RdKafka::wait_destroyed(5000); };
 
 private:
   std::unique_ptr<RdKafka::Producer> m_producer_ptr;
   std::unique_ptr<RdKafka::Topic> m_topic_ptr;
+  std::string m_compression = "";
 };
 
 #endif // ISIS_NEXUS_STREAMER_KAFKAEVENTPUBLISHER_H

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -22,11 +22,14 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
   conf->set("message.max.bytes", "10000000", error_str);
   conf->set("fetch.message.max.bytes", "10000000", error_str);
   conf->set("replica.fetch.max.bytes", "10000000", error_str);
-  //if (conf->set("compression.codec", "snappy", error_str) !=
-  //    RdKafka::Conf::CONF_OK) {
-  //  std::cerr << error_str << std::endl;
-  //  exit(1);
-  //}
+  if (!m_compression.empty()) {
+    if (conf->set("compression.codec", m_compression, error_str) !=
+        RdKafka::Conf::CONF_OK) {
+      std::cerr << error_str << std::endl;
+      exit(1);
+    }
+    std::cout << "Using " << m_compression << " compression codec" << std::endl;
+  }
 
   // Create producer
   m_producer_ptr = std::unique_ptr<RdKafka::Producer>(

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -16,10 +16,11 @@ int main(int argc, char **argv) {
   std::string filename;
   std::string broker = "sakura";
   std::string topic = "test_topic";
+  std::string compression = "";
   bool quietMode = false;
   int messagesPerFrame = 1;
 
-  while ((opt = getopt(argc, argv, "f:b:t:m:q")) != -1) {
+  while ((opt = getopt(argc, argv, "f:b:t:c:m:q")) != -1) {
     switch (opt) {
 
     case 'f':
@@ -32,6 +33,10 @@ int main(int argc, char **argv) {
 
     case 't':
       topic = optarg;
+      break;
+
+    case 'c':
+      compression = optarg;
       break;
 
     case 'm':
@@ -59,7 +64,7 @@ int main(int argc, char **argv) {
     exit(1);
   }
 
-  auto publisher = std::make_shared<KafkaEventPublisher>();
+  auto publisher = std::make_shared<KafkaEventPublisher>(compression);
   NexusPublisher streamer(publisher, broker, topic, filename, quietMode);
   streamer.streamData(messagesPerFrame);
 

--- a/system_tests/measure_compression.py
+++ b/system_tests/measure_compression.py
@@ -1,0 +1,108 @@
+from __future__ import print_function
+import test_utils
+import time
+import os
+import pexpect
+import csv
+import numpy as np
+
+"""
+Crude measurement of the compression ratio achieved.
+Carried out by monitoring network bytesin and bytesout vs time and integrating the curve.
+
+Requires ifstat to be installed
+"""
+
+
+class Ifstat:
+
+    def __init__(self, network_interface):
+        self.ifstat = pexpect.spawn("ifstat -n -i " + network_interface)
+
+    def get_output(self):
+        # Get all output
+        result = ""
+        try:
+            for n in range(1, 10):
+                result = result + self.ifstat.read_nonblocking(size=16777216, timeout=2)
+        except:
+            print("Error reading from ifstat, buffer too small?")
+        return result
+
+    def __del__(self):
+        self.ifstat.close(force=True)
+
+
+def stream_data(build_dir, broker, topic_name, network_interface, data_path, datafile, compression):
+    # Launch the consumer
+    print("Launching consumer...", end="")
+    consumer_process = test_utils.Subprocess(
+        [os.path.join(build_dir, "nexus_consumer", "main_nexusSubscriber"),
+         "-b", broker,
+         "-t", topic_name,
+         "-q"])
+    print(" done.")
+
+    time.sleep(2)
+
+    # Run ifstat to monitor network use
+    ifstat = Ifstat(network_interface)
+
+    # Run the producer
+    print("Launching producer...", end="")
+    if compression:
+        producer_process = test_utils.Subprocess(
+            [os.path.join(build_dir, "nexus_producer", "main_nexusPublisher"),
+             "-f", os.path.join(data_path, datafile),
+             "-b", broker,
+             "-t", topic_name,
+             "-m", "100",
+             "-c", compression,
+             "-q"])
+    else:
+        producer_process = test_utils.Subprocess(
+            [os.path.join(build_dir, "nexus_producer", "main_nexusPublisher"),
+             "-f", os.path.join(data_path, datafile),
+             "-b", broker,
+             "-t", topic_name,
+             "-m", "100",
+             "-q"])
+    print(" done.")
+
+    print("Waiting for consumer to finish...")
+    consumer_process.wait()
+    print("...consumer process completed.")
+
+    ifstat_output = ifstat.get_output()
+
+    print("Waiting for producer to finish...")
+    producer_process.wait()
+    print("...producer process completed.")
+
+    output_strings = ifstat_output.splitlines()[2:]
+    data = []
+    for line in output_strings:
+        data.append([float(i) for i in line.split()])
+    data = np.array(data)
+    print(str(sum(data[:, 0])) + ' KB sent')
+    print(str(sum(data[:, 1])) + ' KB received')
+
+    return sum(data[:, 0])
+
+
+def main():
+
+    build_dir = "/home/jonmd/build_dir/Release/"
+    data_path = "/home/jonmd/git/isis_nexus_streamer.git/data/"
+    datafile = "WISH00034509_uncompressed.hdf5"
+    broker = "tenten"
+    topic_name = "compression_ratio_measure"
+    network_interface = "enp0s31f6"
+
+    size_no_compression = stream_data(build_dir, broker, topic_name, network_interface, data_path, datafile, None)
+    size_with_compression = stream_data(build_dir, broker, topic_name, network_interface, data_path, datafile, "snappy")
+    print("Compression ratio of " + str(size_no_compression/size_with_compression))
+
+
+if __name__ == "__main__":
+    main()

--- a/system_tests/measure_compression.py
+++ b/system_tests/measure_compression.py
@@ -83,10 +83,10 @@ def stream_data(build_dir, broker, topic_name, network_interface, data_path, dat
     for line in output_strings:
         data.append([float(i) for i in line.split()])
     data = np.array(data)
-    print(str(sum(data[:, 0])) + ' KB sent')
-    print(str(sum(data[:, 1])) + ' KB received')
+    print(str(sum(data[:, 1])) + ' KB sent')
+    print(str(sum(data[:, 0])) + ' KB received')
 
-    return sum(data[:, 0])
+    return sum(data[:, 1])
 
 
 def main():

--- a/system_tests/measure_compression.py
+++ b/system_tests/measure_compression.py
@@ -3,7 +3,6 @@ import test_utils
 import time
 import os
 import pexpect
-import csv
 import numpy as np
 
 """


### PR DESCRIPTION
Closes #5 

Added a python script which does a crude measurement of the compression ratio achieved by snappy by monitoring network throughput.