### PR TITLE
Improvements to system tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,7 @@ execute_process(
 )
 
 find_package(PythonInterp REQUIRED)
-set(system_test_args )
-add_custom_target(system_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/system_tests/test.py ${PROJECT_SOURCE_DIR}/data -p -j 9997
+add_custom_target(system_test COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/system_tests/test.py ${PROJECT_SOURCE_DIR}/data -p -z ino
         COMMENT "Executing system tests..." VERBATIM)
 add_custom_target(system_test_virtual COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/system_tests/test.py ${PROJECT_SOURCE_DIR}/data
         COMMENT "Executing system tests..." VERBATIM)

--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ The CMake target for the system tests is `system_test`. Running the tests has th
 - numpy (`pip install numpy`)
 - matplotlib (`pip install matplotlib`)
 - kazoo (`pip install kazoo`)
+
+Usage of the test script can be seen using `python test.py --help`.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@
 # ISIS NeXus Streamer
 Stream event data from a NeXus file from RAL/ISIS using Apache Kafka. A producer and a consumer client are included. Each message sent over the wire consists of a single frame of event mode data.
 
+Producer usage:
+```
+main_nexusPublisher -f <filepath>    NeXus filename including full path
+               [-b <host>]    Hostname of a broker in the Kafka cluster
+               [-t <topic_name>]    Name of the topic to publish to
+               [-m <messages_per_frame>]    Number of messages per frame
+               [-q]    Quiet mode, make publisher less chatty
+               [-u]    Random mode, serve messages within each frame in a random order
+```
+
+Consumer usage:
+```
+main_nexusSubscriber
+               [-b <host>]    NeXus filename including full path
+               [-t <topic_name>]    Name of the topic to subscribe to
+               [-f <filepath>]    Write the received data to a NeXus file with this full path
+               [-q]    Quiet mode, make the client less chatty
+```
+
 ## Dependencies
 Currently requires having `librdkafka` and the HDF5 C++ library installed. If `tcmalloc` is available then it will be used, but it is not a requirement.
 

--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ The CMake target for the system tests is `system_test`. Running the tests has th
 - python-vagrant (`pip install python-vagrant`)
 - numpy (`pip install numpy`)
 - matplotlib (`pip install matplotlib`)
+- kazoo (`pip install kazoo`)

--- a/nexus_consumer/src/main.cpp
+++ b/nexus_consumer/src/main.cpp
@@ -38,11 +38,11 @@ int main(int argc, char **argv) {
       break;
 
     default:
-      fprintf(stderr, "Usage: %s "
-                      "[-b <host>] "
-                      "[-t <topic_name>]"
-                      "[-f <filename>]"
-                      "[-q]"
+      fprintf(stderr, "Usage: %s \n"
+                      "[-b <host>]    NeXus filename including full path\n"
+                      "[-t <topic_name>]    Name of the topic to subscribe to\n"
+                      "[-f <filepath>]    Write the received data to a NeXus file with this full path\n"
+                      "[-q]    Quiet mode, make the client less chatty\n"
                       "\n",
               argv[0]);
       exit(1);

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
   bool randomMode = false;
   int messagesPerFrame = 1;
 
-  while ((opt = getopt(argc, argv, "f:b:t:c:m:qr")) != -1) {
+  while ((opt = getopt(argc, argv, "f:b:t:c:m:qu")) != -1) {
     switch (opt) {
 
     case 'f':
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
       quietMode = true;
       break;
 
-    case 'r':
+    case 'u':
       randomMode = true;
       break;
 
@@ -60,11 +60,11 @@ int main(int argc, char **argv) {
   if (filename.empty()) {
   usage:
     fprintf(stderr, "Usage: %s -f <filepath>    NeXus filename including full path\n"
-                    "[-b <host>]    hostname of a broker in the Kafka cluster\n"
-                    "[-t <topic_name>]    name of the topic to publish to\n"
-                    "[-m <messages_per_frame>]    number of messages per frame\n"
-                    "[-q]    quiet mode, make publisher less chatty\n"
-                    "[-r]    random mode, serve messages within each frame in a random order\n"
+                    "[-b <host>]    Hostname of a broker in the Kafka cluster\n"
+                    "[-t <topic_name>]    Name of the topic to publish to\n"
+                    "[-m <messages_per_frame>]    Number of messages per frame\n"
+                    "[-q]    Quiet mode, make publisher less chatty\n"
+                    "[-u]    Random mode, serve messages within each frame in a random order\n"
                     "\n",
             argv[0]);
     exit(1);

--- a/system_tests/test_utils/__init__.py
+++ b/system_tests/test_utils/__init__.py
@@ -4,3 +4,4 @@ from jmxmetrics import *
 from jmxtool import *
 from kafkasubprocess import *
 from utils import *
+from kafkainfo import *

--- a/system_tests/test_utils/kafkainfo.py
+++ b/system_tests/test_utils/kafkainfo.py
@@ -11,6 +11,10 @@ class KafkaInfo(object):
         broker_ids = self.zk.get_children('/brokers/ids')
         return [json.loads(self.zk.get('brokers/ids/'+broker_id)[0])['host'] for broker_id in broker_ids]
 
+    def jmxports(self):
+        broker_ids = self.zk.get_children('/brokers/ids')
+        return [json.loads(self.zk.get('brokers/ids/'+broker_id)[0])['jmx_port'] for broker_id in broker_ids]
+
     def topics(self):
         return self.zk.get_children('/brokers/topics')
 

--- a/system_tests/test_utils/kafkainfo.py
+++ b/system_tests/test_utils/kafkainfo.py
@@ -1,0 +1,29 @@
+from kazoo.client import KazooClient
+import json
+
+
+class KafkaInfo(object):
+    def __init__(self, hosts):
+        self.zk = KazooClient(hosts)
+        self.zk.start()
+
+    def brokers(self):
+        broker_ids = self.zk.get_children('/brokers/ids')
+        return [json.loads(self.zk.get('brokers/ids/'+broker_id)[0])['host'] for broker_id in broker_ids]
+
+    def topics(self):
+        return self.zk.get_children('/brokers/topics')
+
+    def partitions(self, topic):
+        strs = self.zk.get_children('/brokers/topics/%s/partitions' % topic)
+        return map(int, strs)
+
+    def consumers(self):
+        return self.zk.get_children('/consumers')
+
+    def topics_for_consumer(self, consumer):
+        return self.zk.get_children('/consumers/%s/offsets' % consumer)
+
+    def offset(self, topic, consumer, partition):
+        (n, _) = self.zk.get('/consumers/%s/offsets/%s/%d' % (consumer, topic, partition))
+        return int(n)


### PR DESCRIPTION
Closes #13 
Closes #16 
Closes #11

The name of the zookeeper host can now be given to the system test script, the names of the brokers and the jmxports are collected from zookeeper automatically.
The default nexus file used in the test is now "SANS_test_uncompressed.hdf5". This is not a large enough file to collect useful metrics, but is at least in the repository.
The README has been updated.