### PR TITLE
Vary number of messages per frame

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,11 +154,11 @@ file(COPY ${PROJECT_SOURCE_DIR}/system_tests DESTINATION ${CMAKE_CURRENT_BINARY_
 # if the file already exists with the correct checksum then it won't be redownloaded
 file(DOWNLOAD http://downloads.sourceforge.net/cyclops-group/jmxterm-1.0-alpha-4-uber.jar
         ${CMAKE_CURRENT_BINARY_DIR}/system_tests/jmxterm.jar
-        TIMEOUT 30
+        TIMEOUT 60
         EXPECTED_MD5 f3c307163673d9f70c27b3f440df9dd4)
 file(DOWNLOAD http://mirror.ox.ac.uk/sites/rsync.apache.org/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz
         ${CMAKE_CURRENT_BINARY_DIR}/system_tests/kafka_2.11-0.9.0.1.tgz
-        TIMEOUT 30
+        TIMEOUT 60
         EXPECTED_MD5 b71e5cbc78165c1ca483279c27402663)
 execute_process(
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/system_tests/kafka_2.11-0.9.0.1.tgz

--- a/event_data/include/EventData.h
+++ b/event_data/include/EventData.h
@@ -27,6 +27,8 @@ public:
   };
   void setFrameNumber(uint32_t frameNumber) { m_frameNumber = frameNumber; }
   void setTotalCounts(uint64_t totalCounts) { m_totalCounts = totalCounts; }
+  void setEndFrame(bool lastInFrame) { m_endFrame = lastInFrame; }
+  void setEndRun(bool lastInRun) { m_endRun = lastInRun; }
 
   // Getters
   std::vector<uint32_t> getDetId() { return m_detId; }
@@ -35,6 +37,8 @@ public:
   uint32_t getFrameNumber() { return m_frameNumber; }
   uint32_t getNumberOfEvents() { return m_tof.size(); }
   uint64_t getTotalCounts() { return m_totalCounts; }
+  bool getEndFrame() { return m_endFrame; }
+  bool getEndRun() { return m_endRun; }
 
   flatbuffers::unique_ptr_t getBufferPointer(std::string &buffer, uint64_t messageID);
 
@@ -47,6 +51,8 @@ private:
   uint32_t m_frameNumber;
   uint64_t m_totalCounts;
   size_t m_bufferSize;
+  bool m_endFrame = false;
+  bool m_endRun = false;
 };
 
 #endif // ISIS_NEXUS_STREAMER_EVENTDATA_H

--- a/event_data/include/eventDataFlatBuffer_generated.h
+++ b/event_data/include/eventDataFlatBuffer_generated.h
@@ -33,7 +33,9 @@ struct FlatbufEventData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_TOF = 8,
     VT_FRAMENUMBER = 10,
     VT_TOTALFRAMES = 12,
-    VT_TOTALCOUNTS = 14
+    VT_TOTALCOUNTS = 14,
+    VT_FRAMEEND = 16,
+    VT_RUNEND = 18
   };
   uint32_t count() const { return GetField<uint32_t>(VT_COUNT, 0); }
   const flatbuffers::Vector<uint32_t> *detId() const { return GetPointer<const flatbuffers::Vector<uint32_t> *>(VT_DETID); }
@@ -41,6 +43,8 @@ struct FlatbufEventData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint32_t frameNumber() const { return GetField<uint32_t>(VT_FRAMENUMBER, 0); }
   uint32_t totalFrames() const { return GetField<uint32_t>(VT_TOTALFRAMES, 0); }
   uint64_t totalCounts() const { return GetField<uint64_t>(VT_TOTALCOUNTS, 0); }
+  bool frameEnd() const { return GetField<uint8_t>(VT_FRAMEEND, 0) != 0; }
+  bool runEnd() const { return GetField<uint8_t>(VT_RUNEND, 0) != 0; }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint32_t>(verifier, VT_COUNT) &&
@@ -51,6 +55,8 @@ struct FlatbufEventData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<uint32_t>(verifier, VT_FRAMENUMBER) &&
            VerifyField<uint32_t>(verifier, VT_TOTALFRAMES) &&
            VerifyField<uint64_t>(verifier, VT_TOTALCOUNTS) &&
+           VerifyField<uint8_t>(verifier, VT_FRAMEEND) &&
+           VerifyField<uint8_t>(verifier, VT_RUNEND) &&
            verifier.EndTable();
   }
 };
@@ -64,10 +70,12 @@ struct FlatbufEventDataBuilder {
   void add_frameNumber(uint32_t frameNumber) { fbb_.AddElement<uint32_t>(FlatbufEventData::VT_FRAMENUMBER, frameNumber, 0); }
   void add_totalFrames(uint32_t totalFrames) { fbb_.AddElement<uint32_t>(FlatbufEventData::VT_TOTALFRAMES, totalFrames, 0); }
   void add_totalCounts(uint64_t totalCounts) { fbb_.AddElement<uint64_t>(FlatbufEventData::VT_TOTALCOUNTS, totalCounts, 0); }
+  void add_frameEnd(bool frameEnd) { fbb_.AddElement<uint8_t>(FlatbufEventData::VT_FRAMEEND, static_cast<uint8_t>(frameEnd), 0); }
+  void add_runEnd(bool runEnd) { fbb_.AddElement<uint8_t>(FlatbufEventData::VT_RUNEND, static_cast<uint8_t>(runEnd), 0); }
   FlatbufEventDataBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) { start_ = fbb_.StartTable(); }
   FlatbufEventDataBuilder &operator=(const FlatbufEventDataBuilder &);
   flatbuffers::Offset<FlatbufEventData> Finish() {
-    auto o = flatbuffers::Offset<FlatbufEventData>(fbb_.EndTable(start_, 6));
+    auto o = flatbuffers::Offset<FlatbufEventData>(fbb_.EndTable(start_, 8));
     return o;
   }
 };
@@ -78,7 +86,9 @@ inline flatbuffers::Offset<FlatbufEventData> CreateFlatbufEventData(flatbuffers:
    flatbuffers::Offset<flatbuffers::Vector<uint64_t>> tof = 0,
    uint32_t frameNumber = 0,
    uint32_t totalFrames = 0,
-   uint64_t totalCounts = 0) {
+   uint64_t totalCounts = 0,
+   bool frameEnd = false,
+   bool runEnd = false) {
   FlatbufEventDataBuilder builder_(_fbb);
   builder_.add_totalCounts(totalCounts);
   builder_.add_totalFrames(totalFrames);
@@ -86,6 +96,8 @@ inline flatbuffers::Offset<FlatbufEventData> CreateFlatbufEventData(flatbuffers:
   builder_.add_tof(tof);
   builder_.add_detId(detId);
   builder_.add_count(count);
+  builder_.add_runEnd(runEnd);
+  builder_.add_frameEnd(frameEnd);
   return builder_.Finish();
 }
 

--- a/event_data/src/EventData.cpp
+++ b/event_data/src/EventData.cpp
@@ -29,6 +29,8 @@ void EventData::decodeMessage(const uint8_t *buf) {
     setNumberOfFrames(eventData->totalFrames());
     setFrameNumber(eventData->frameNumber());
     setTotalCounts(eventData->totalCounts());
+    setEndFrame(eventData->frameEnd());
+    setEndRun(eventData->runEnd());
   } else {
     std::cout << "Unrecognised message type" << std::endl;
   }
@@ -42,7 +44,7 @@ flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer, uint6
 
   auto messageFlatbuf = CreateFlatbufEventData(
       builder, static_cast<int32_t>(m_detId.size()), detIdsVector, tofsVector,
-      m_frameNumber, m_numberOfFrames, m_totalCounts);
+      m_frameNumber, m_numberOfFrames, m_totalCounts, m_endFrame, m_endRun);
 
   auto messageOffset = CreateEventMessage(
       builder, MessageTypes_FlatbufEventData, messageFlatbuf.Union(), messageID);

--- a/event_data/src/eventDataFlatBuffer.fbs
+++ b/event_data/src/eventDataFlatBuffer.fbs
@@ -7,6 +7,8 @@ table FlatbufEventData {
     frameNumber:uint;
     totalFrames:uint;
     totalCounts:ulong;
+    frameEnd:bool = false;
+    runEnd:bool = false;
 }
 
 union MessageTypes { FlatbufEventData }

--- a/event_data/test/EventDataTest.cpp
+++ b/event_data/test/EventDataTest.cpp
@@ -25,6 +25,8 @@ TEST(EventDataTest, get_buffer_pointer) {
   EXPECT_NO_THROW(events.setTof(tofs));
   EXPECT_NO_THROW(events.setNumberOfFrames(numberOfFrames));
   EXPECT_NO_THROW(events.setFrameNumber(frameNumber));
+  EXPECT_NO_THROW(events.setEndRun(true));
+  EXPECT_NO_THROW(events.setEndFrame(true));
 
   std::string rawbuf;
   EXPECT_NO_THROW(events.getBufferPointer(rawbuf, messageID));
@@ -37,6 +39,8 @@ TEST(EventDataTest, get_buffer_pointer) {
   EXPECT_EQ(tofs, receivedEventData.getTof());
   EXPECT_EQ(numberOfFrames, receivedEventData.getNumberOfFrames());
   EXPECT_EQ(frameNumber, receivedEventData.getFrameNumber());
+  EXPECT_TRUE(receivedEventData.getEndRun());
+  EXPECT_TRUE(receivedEventData.getEndFrame());
 }
 
 TEST(EventDataTest, get_buffer_size) {

--- a/nexus_consumer/include/NexusSubscriber.h
+++ b/nexus_consumer/include/NexusSubscriber.h
@@ -12,10 +12,8 @@ struct ReceivedDataStats {
   int32_t frameNumber = 0;
   int32_t numberOfFrames = 2;
   int64_t totalBytesReceived = 0;
-  int32_t numberOfmessagesReceived = 0;
-  int32_t previousFrameNumber = std::numeric_limits<int32_t>::max();
+  int32_t numberOfMessagesReceived = 0;
   int numberOfFramesReceived = 0; // to check no messages lost
-  int messagesPerFrame = 1;
   uint64_t previousMessageID = std::numeric_limits<uint64_t>::max();
 };
 
@@ -35,6 +33,7 @@ private:
   std::shared_ptr<EventSubscriber> m_subscriber;
   std::shared_ptr<NexusFileWriter> m_filewriter;
   bool m_quietMode = false;
+  bool m_running = false;
   std::unordered_map<uint64_t, std::string> m_futureMessages;
 
   void processMessage(std::shared_ptr<EventData> receivedData,

--- a/nexus_consumer/src/NexusSubscriber.cpp
+++ b/nexus_consumer/src/NexusSubscriber.cpp
@@ -33,13 +33,13 @@ void NexusSubscriber::listen() {
       continue;
 
     decodeMessage(receivedData, message, receivedDataStats);
-
+    std::cout << m_futureMessages.size() << std::endl;
     if (m_futureMessages.size() > 128) {
-      std::cout << "Error: A message is missing and 128 messages have been "
-          "received since it was supposed to be received. Aborting "
-          "listen."
-                << std::endl;
       m_running = false;
+      throw std::runtime_error(
+          "A message is missing and 128 messages have been "
+          "received since it was supposed to be received. Aborting "
+          "listen.");
     }
   }
   reportProgress(1.0);

--- a/nexus_consumer/src/NexusSubscriber.cpp
+++ b/nexus_consumer/src/NexusSubscriber.cpp
@@ -33,7 +33,6 @@ void NexusSubscriber::listen() {
       continue;
 
     decodeMessage(receivedData, message, receivedDataStats);
-    std::cout << m_futureMessages.size() << std::endl;
     if (m_futureMessages.size() > 128) {
       m_running = false;
       throw std::runtime_error(

--- a/nexus_consumer/test/NexusSubscriberTest.cpp
+++ b/nexus_consumer/test/NexusSubscriberTest.cpp
@@ -290,6 +290,7 @@ TEST_F(NexusSubscriberTest, test_listener_throws_if_message_missing) {
   for (uint64_t messageID = 0; messageID < 131; messageID++) {
     auto exampleEventData =
         createEventData(static_cast<uint32_t>(messageID));
+    // Make the second message never arrive
     if (messageID != 1) {
       EXPECT_NO_THROW(exampleEventData->getBufferPointer(rawbuf, messageID));
       EXPECT_CALL(*subscriber.get(), listenForMessage(_))

--- a/nexus_consumer/test/NexusSubscriberTest.cpp
+++ b/nexus_consumer/test/NexusSubscriberTest.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 
+#include "../../nexus_file_reader/include/NexusFileReader.h"
 #include "EventData.h"
 #include "MockEventSubscriber.h"
 #include "NexusSubscriber.h"
-#include "../../nexus_file_reader/include/NexusFileReader.h"
 
 using ::testing::AtLeast;
 using ::testing::_;
@@ -31,12 +31,37 @@ public:
     return exampleEventData;
   }
 
-  std::shared_ptr<EventData> createEventData(std::vector<uint32_t> detIds, uint32_t frameNumber) {
+  std::shared_ptr<EventData> createEventData(std::vector<uint32_t> detIds,
+                                             uint32_t frameNumber) {
     auto exampleEventData = std::make_shared<EventData>();
 
     std::vector<uint64_t> tofs = {4, 3, 2, 1};
     uint32_t numberOfFrames = 3;
     uint64_t totalCounts = 12;
+
+    exampleEventData->setDetId(detIds);
+    exampleEventData->setTof(tofs);
+    exampleEventData->setNumberOfFrames(numberOfFrames);
+    exampleEventData->setFrameNumber(frameNumber);
+    exampleEventData->setTotalCounts(totalCounts);
+
+    return exampleEventData;
+  }
+
+  std::shared_ptr<EventData> createEventData(uint32_t frameNumber) {
+    auto exampleEventData = std::make_shared<EventData>();
+
+    std::vector<uint64_t> tofs = {4, 3, 2, 1};
+    std::vector<uint32_t> detIds = {1, 2, 3, 4};
+    uint32_t numberOfFrames = 130;
+    uint64_t totalCounts = 520;
+
+    // 1 message per frame
+    exampleEventData->setEndFrame(true);
+
+    if (frameNumber == (numberOfFrames - 1)) {
+      exampleEventData->setEndRun(true);
+    }
 
     exampleEventData->setDetId(detIds);
     exampleEventData->setTof(tofs);
@@ -216,7 +241,8 @@ TEST_F(NexusSubscriberTest, test_listen_for_messages_received_out_of_order) {
 
   NexusSubscriber streamer(subscriber, broker, topic, false, testfileFullPath);
 
-  // Should be called exactly three times because there are messages containing the
+  // Should be called exactly three times because there are messages containing
+  // the
   // last three frames
   EXPECT_CALL(*subscriber.get(), listenForMessage(_))
       .WillOnce(DoAll(SetArgReferee<0>(rawbuf_first), Return(true)))
@@ -240,4 +266,36 @@ TEST_F(NexusSubscriberTest, test_listen_for_messages_received_out_of_order) {
 
   // clean up the file created
   std::remove(testfileFullPath.c_str());
+}
+
+TEST_F(NexusSubscriberTest, test_listener_throws_if_message_missing) {
+  // If a message is not received, even after waiting for 128 further messages,
+  // then throw an exception should be thrown
+  using ::testing::Sequence;
+
+  const std::string broker = "broker_name";
+  const std::string topic = "topic_name";
+
+  extern std::string testDataPath;
+  const std::string testfileFullPath =
+      testDataPath + "temp_unit_test_file.hdf5";
+
+  auto subscriber = std::make_shared<MockEventSubscriber>();
+  EXPECT_CALL(*subscriber.get(), setUp(broker, topic)).Times(AtLeast(1));
+
+  NexusSubscriber streamer(subscriber, broker, topic, false, "");
+
+  Sequence s1;
+  std::string rawbuf;
+  for (uint64_t messageID = 0; messageID < 131; messageID++) {
+    auto exampleEventData =
+        createEventData(static_cast<uint32_t>(messageID));
+    if (messageID != 1) {
+      EXPECT_NO_THROW(exampleEventData->getBufferPointer(rawbuf, messageID));
+      EXPECT_CALL(*subscriber.get(), listenForMessage(_))
+          .InSequence(s1)
+          .WillOnce(DoAll(SetArgReferee<0>(rawbuf), Return(true)));
+    }
+  }
+  EXPECT_THROW(streamer.listen(), std::runtime_error);
 }

--- a/nexus_consumer/test/NexusSubscriberTest.cpp
+++ b/nexus_consumer/test/NexusSubscriberTest.cpp
@@ -121,6 +121,8 @@ TEST_F(NexusSubscriberTest, test_listen_for_messages_one_received) {
 
   auto exampleEventData = createEventData();
   // Make this the last frame so that listenForMessage will only be called once
+  exampleEventData->setEndFrame(true);
+  exampleEventData->setEndRun(true);
   exampleEventData->setNumberOfFrames(9);
   exampleEventData->setFrameNumber(9);
   std::string rawbuf;
@@ -156,6 +158,8 @@ TEST_F(NexusSubscriberTest, test_listen_for_messages_multiple_received) {
   auto exampleEventData_second = createEventData();
   exampleEventData_second->setNumberOfFrames(9);
   exampleEventData_second->setFrameNumber(8);
+  exampleEventData_second->setEndFrame(true);
+  exampleEventData_second->setEndRun(true);
   std::string rawbuf_second;
   EXPECT_NO_THROW(
       exampleEventData_second->getBufferPointer(rawbuf_second, messageID + 1));
@@ -201,6 +205,8 @@ TEST_F(NexusSubscriberTest, test_listen_for_messages_received_out_of_order) {
   // Last frame
   std::vector<uint32_t> thirdIds = {3, 3, 3, 3};
   auto exampleEventData_third = createEventData(thirdIds, 2);
+  exampleEventData_third->setEndFrame(true);
+  exampleEventData_third->setEndRun(true);
   std::string rawbuf_third;
   EXPECT_NO_THROW(
       exampleEventData_third->getBufferPointer(rawbuf_third, messageID + 2));

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -17,6 +17,7 @@ public:
   bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber);
   bool getEventTofs(std::vector<uint64_t> &tofs, hsize_t frameNumber);
   size_t getNumberOfFrames() { return m_numberOfFrames; };
+  std::vector<int> getFramePartsPerFrame(int maxEventsPerMessage);
 
 private:
   hsize_t getFrameStart(hsize_t frameNumber);

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -22,6 +22,7 @@ public:
 private:
   hsize_t getFrameStart(hsize_t frameNumber);
   hsize_t getNumberOfEventsInFrame(hsize_t frameNumber);
+  size_t getNumberOfFramesFromFile();
   H5FilePtr m_file = nullptr;
   size_t m_numberOfFrames;
 };

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -1,5 +1,6 @@
 #include "../include/NexusFileReader.h"
 #include <iostream>
+#include <cmath>
 
 using namespace H5;
 
@@ -148,4 +149,16 @@ bool NexusFileReader::getEventTofs(std::vector<uint64_t> &tofs,
   }
 
   return true;
+}
+
+std::vector<int>
+NexusFileReader::getFramePartsPerFrame(int maxEventsPerMessage) {
+  std::vector<int> framePartsPerFrame;
+  framePartsPerFrame.resize(m_numberOfFrames);
+  for (hsize_t frameNumber = 0; frameNumber < m_numberOfFrames; frameNumber++) {
+    framePartsPerFrame[frameNumber] = static_cast<int>(
+        std::ceil(static_cast<float>(getNumberOfEventsInFrame(frameNumber)) /
+                  static_cast<float>(maxEventsPerMessage)));
+  }
+  return framePartsPerFrame;
 }

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -156,9 +156,15 @@ NexusFileReader::getFramePartsPerFrame(int maxEventsPerMessage) {
   std::vector<int> framePartsPerFrame;
   framePartsPerFrame.resize(m_numberOfFrames);
   for (hsize_t frameNumber = 0; frameNumber < m_numberOfFrames; frameNumber++) {
-    framePartsPerFrame[frameNumber] = static_cast<int>(
+    int frameParts = static_cast<int>(
         std::ceil(static_cast<float>(getNumberOfEventsInFrame(frameNumber)) /
                   static_cast<float>(maxEventsPerMessage)));
+    // If there are no events in the frame a message should still be sent
+    // otherwise the output file will not match the input file
+    if (frameParts > 0)
+      framePartsPerFrame[frameNumber] = frameParts;
+    else
+      framePartsPerFrame[frameNumber] = 1;
   }
   return framePartsPerFrame;
 }

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -70,3 +70,10 @@ TEST(NexusFileReaderTest, get_event_tofs_too_high_frame_number) {
   std::vector<uint64_t> eventTofs;
   EXPECT_FALSE(fileReader.getEventTofs(eventTofs, 3000000));
 }
+
+TEST(NexusFileReaderTest, get_frame_parts_per_frame) {
+  extern std::string testDataPath;
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5");
+  auto framePartsPerFrame = fileReader.getFramePartsPerFrame(200);
+  EXPECT_EQ(4, framePartsPerFrame[0]);
+}

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -36,7 +36,7 @@ TEST(NexusFileReaderTest, nexus_read_number_events) {
 TEST(NexusFileReaderTest, nexus_read_number_frames) {
   extern std::string testDataPath;
   auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
-  EXPECT_EQ(18131, fileReader.getNumberOfFrames());
+  EXPECT_EQ(18132, fileReader.getNumberOfFrames());
 }
 
 TEST(NexusFileReaderTest, get_detIds_first_frame) {

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -15,7 +15,7 @@ public:
                  const bool quietMode, const bool randomMode);
   std::vector<std::shared_ptr<EventData>>
   createMessageData(hsize_t frameNumber, const int messagesPerFrame);
-  void streamData(const int messagesPerFrame);
+  void streamData(const int maxEventsPerFramePart);
 
 private:
   int64_t createAndSendMessage(std::string &rawbuf, size_t frameNumber,

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
   std::string compression = "";
   bool quietMode = false;
   bool randomMode = false;
-  int messagesPerFrame = 1;
+  int maxEventsPerFramePart = 200;
 
   while ((opt = getopt(argc, argv, "f:b:t:c:m:qr")) != -1) {
     switch (opt) {
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
       break;
 
     case 'm':
-      messagesPerFrame = std::stoi(optarg);
+      maxEventsPerFramePart = std::stoi(optarg);
       break;
 
     case 'q':
@@ -62,7 +62,8 @@ int main(int argc, char **argv) {
     fprintf(stderr, "Usage: %s -f <filepath>    NeXus filename including full path\n"
                     "[-b <host>]    hostname of a broker in the Kafka cluster\n"
                     "[-t <topic_name>]    name of the topic to publish to\n"
-                    "[-m <messages_per_frame>]    number of messages per frame\n"
+                    "[-m <max_events_per_message>]   Maximum number of events to send "
+                    "in a single message, default is 200\n"
                     "[-q]    quiet mode, make publisher less chatty\n"
                     "[-r]    random mode, serve messages within each frame in a random order\n"
                     "\n",
@@ -72,7 +73,7 @@ int main(int argc, char **argv) {
 
   auto publisher = std::make_shared<KafkaEventPublisher>(compression);
   NexusPublisher streamer(publisher, broker, topic, filename, quietMode, randomMode);
-  streamer.streamData(messagesPerFrame);
+  streamer.streamData(maxEventsPerFramePart);
 
   return 0;
 }

--- a/system_tests/test.py
+++ b/system_tests/test.py
@@ -140,7 +140,7 @@ def launch_producer(args):
              "-f", os.path.join(args.data_path, args.datafile),
              "-b", args.broker,
              "-t", args.topic_name,
-             "-m", "10",
+             "-m", "200",
              "-r",
              "-q"])
     else:
@@ -149,7 +149,7 @@ def launch_producer(args):
              "-f", os.path.join(args.data_path, args.datafile),
              "-b", args.broker,
              "-t", args.topic_name,
-             "-m", "1",
+             "-m", "200",
              "-q"])
     print(" done.")
     return producer_process

--- a/system_tests/test_utils/utils.py
+++ b/system_tests/test_utils/utils.py
@@ -25,7 +25,6 @@ def nexus_files_equal(filename_1, filename_2):
     ]
     scalar_datasets = [
         '/raw_data_1/detector_1_events/total_counts',
-        '/raw_data_1/good_frames'
     ]
     # larger datasets will be read and compared in smaller slices
     datasets = [


### PR DESCRIPTION
Fixes #4 
Send a varying number of messages per frame, such that never more than the optarg `max_events_per_message` are in a single message. This solves the bug where the program would throw an exception if more messages per frame were requested than there were events in a frame. It also results in more evenly sized messages.