### PR TITLE
Report ID of missing message

### DIFF
--- a/nexus_consumer/src/KafkaEventSubscriber.cpp
+++ b/nexus_consumer/src/KafkaEventSubscriber.cpp
@@ -25,6 +25,10 @@ void KafkaEventSubscriber::setUp(const std::string &broker_str,
   conf->set("fetch.message.max.bytes", "10000000", error_str);
   conf->set("replica.fetch.max.bytes", "10000000", error_str);
   conf->set("group.id", "nexus_stream_consumer", error_str);
+  conf->set("enable.auto.commit", "false", error_str);
+  conf->set("enable.auto.offset.store", "false", error_str);
+  conf->set("offset.store.method", "none", error_str);
+  conf->set("auto.offset.reset", "largest", error_str);
 
   // Create consumer using accumulated global configuration.
   m_consumer_ptr = std::unique_ptr<RdKafka::KafkaConsumer>(

--- a/nexus_consumer/src/NexusSubscriber.cpp
+++ b/nexus_consumer/src/NexusSubscriber.cpp
@@ -35,10 +35,16 @@ void NexusSubscriber::listen() {
     decodeMessage(receivedData, message, receivedDataStats);
     if (m_futureMessages.size() > 128) {
       m_running = false;
-      throw std::runtime_error(
+      uint64_t smallestID = std::numeric_limits<uint64_t>::max();
+      for (auto messageID : m_futureMessages) {
+        if (messageID.first < smallestID)
+          smallestID = messageID.first;
+      }
+      std::string missingError =
           "A message is missing and 128 messages have been "
           "received since it was supposed to be received. Aborting "
-          "listen.");
+          "listen. Missing message ID: ";
+      throw std::runtime_error(missingError + std::to_string(smallestID - 1));
     }
   }
   reportProgress(1.0);


### PR DESCRIPTION
The consumer was hitting a runtime error and reporting that there is a missing message. I have added the ID of the missing message to the error string.
The error turned out to be due to using the new API; the consumer was trying to resume from the last offset consumed. It is now starting at the largest offset, the same behaviour as before the API change.